### PR TITLE
feat: add 'destory' to rendered components

### DIFF
--- a/packages/debrix-compiler/crates/debrix_compiler/src/render/dom/renderer.rs
+++ b/packages/debrix-compiler/crates/debrix_compiler/src/render/dom/renderer.rs
@@ -487,12 +487,12 @@ impl Renderer {
 
 			document
 				.write("\tconstructor({ props = {} } = {}) {\n")
-				.write("\t\tlet data = new ")
+				.write("\t\tthis.__data = new ")
 				.write(name)
 				.write("({ props });\n")
 				.write("\t\tthis.__node = ")
 				.write(&render_ident)
-				.write(".apply(data);\n");
+				.write(".apply(this.__data);\n");
 		} else {
 			document
 				.write("\tconstructor() {\n")
@@ -507,6 +507,10 @@ impl Renderer {
 			.write("\t\t")
 			.write(&append_helper)
 			.write("(target, [this.__node], anchor);\n")
+			.write("\t}\n")
+			.write("\tdestroy() {\n")
+			.write("\tthis.__data && this.__data.dispose();\n")
+			.write("\tthis.__node.remove();\n")
 			.write("\t}\n")
 			.write("}\n");
 
@@ -752,7 +756,8 @@ impl Renderer {
 
 		for binding in bindings.nodes {
 			let declarations = self.declarations.get(USAGE_BINDER);
-			let declaration = declarations.and_then(|declarations| declarations.get(&binding.name.name));
+			let declaration =
+				declarations.and_then(|declarations| declarations.get(&binding.name.name));
 
 			if declaration.is_none() {
 				return Err(Error::compiler(

--- a/packages/debrix/src/model.ts
+++ b/packages/debrix/src/model.ts
@@ -190,6 +190,8 @@ export abstract class Model {
 		throw new Error('proxy was bypassed');
 	}
 
+	abstract dispose?(): void;
+
 	constructor(options?: ModelOptions) {
 		this.$e = createEvents();
 		this.$q = new Map<object, Set<symbol | string>>();

--- a/packages/debrix/src/viewmodel.ts
+++ b/packages/debrix/src/viewmodel.ts
@@ -7,7 +7,7 @@ export interface Computed<T = unknown> {
 	observe(listener: SubscriptionListener): Subscription;
 }
 
-export class ViewModel extends Model {
+export abstract class ViewModel extends Model {
 	constructor(options: ModelOptions = {}) {
 		options.ticker ??= createFrameTicker();
 		super(options);


### PR DESCRIPTION
This is required by the componenet declaration. 'destory' removes the
root node and disposes potential instantiated data.