### PR TITLE
fix: exception when error is thrown

### DIFF
--- a/packages/debrix-compiler/crates/node/src/lib.rs
+++ b/packages/debrix-compiler/crates/node/src/lib.rs
@@ -37,7 +37,7 @@ fn build(mut cx: FunctionContext) -> JsResult<JsObject> {
 					cx.throw(js_err)
 				}
 				debrix_compiler::Error::CompilerError(err) => {
-					let js_err = cx.error(format!("{:?}", err))?;
+					let js_err = cx.empty_object();
 
 					let js_type = cx.number(0);
 					let js_message = cx.string(format!("{:?}", err));


### PR DESCRIPTION
It is a mistake that an Error should be thrown from lib.rs. A object should be thrown, which is later on converted into a CompilerError.

Fixes #52