### PR TITLE
fix: spread attribute renders nothing

### DIFF
--- a/packages/debrix-internal/src/reactivity.ts
+++ b/packages/debrix-internal/src/reactivity.ts
@@ -41,23 +41,24 @@ export function bind_attr<N extends Element>(node: N, attr: string, accessor: Co
 
 export type AttributeMap = {
 	readonly [_ in string]?: string;
-} & {
-	readonly $names: ReadonlySet<string>;
 };
 
 export function bind_attr_spread<N extends Element>(node: N, accessor: Computed<AttributeMap>): Lifecycle {
 	const render = () => {
 		const attrs = accessor.get();
 
-		for (const name of attrs.$names) {
-			const value = attrs[name];
+		for (const name in attrs) {
+			if (Object.prototype.hasOwnProperty.call(attrs, name)) {
+				const value = attrs[name];
 
-			// This is correct. I want to check if value is '' or undefined.
-			// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-			if (value)
-				node.setAttribute(name, value);
-			else
-				node.removeAttribute(name);
+				// This is correct. I want to check if value is '' or undefined.
+				// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+				if (value)
+					node.setAttribute(name, value);
+				else
+					node.removeAttribute(name);
+				
+			}
 		}
 	};
 


### PR DESCRIPTION
Essentially moves the model to be owned by `self`, instead of `self.attrs`.

Fixes #56.